### PR TITLE
Use uniform badges via shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ can be used as the back end for CHIP-8 emulator projects / debuggers etc.
 
 Status
 ==
-[![Build Status](https://travis-ci.org/chip8-rust/chip8-vm.svg?branch=master)](https://travis-ci.org/chip8-rust/chip8-vm) [![Build status](https://ci.appveyor.com/api/projects/status/4j05j1xokuc8m8pv/branch/master?svg=true)](https://ci.appveyor.com/project/robo9k/chip8-vm/branch/master)
+[![travis-badge][]][travis] [![appveyor-badge][]][appveyor]
 * All 35 original Chip-8 instructions are implemented.
 
 Usage
@@ -41,3 +41,8 @@ They were both incredibly helpful. Our thanks to the authors!
 Licence
 ==
 MIT
+
+[travis-badge]: https://img.shields.io/travis/chip8-rust/chip8-vm/master.svg?label=linux%20build
+[travis]: https://travis-ci.org/chip8-rust/chip8-vm
+[appveyor-badge]: https://img.shields.io/appveyor/ci/robo9k/chip8-vm/master.svg?label=windows%20build
+[appveyor]: https://ci.appveyor.com/project/robo9k/chip8-vm/branch/master


### PR DESCRIPTION
The default badges from `Travis CI` and `AppVeyor CI` for Linux and Windows builds respectively are not clear in their meaning. Replace them with uniform versions and better labels via [shields.io](http://shields.io/).

Their service also allows to create other badges like;
- [![crates.io](https://img.shields.io/crates/v/chip8_vm.svg)](https://crates.io/crates/chip8_vm) (updates version number automatically)
- [![license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/chip8-rust/chip8-vm/blob/master/LICENSE)
- [![rustdoc](https://img.shields.io/badge/API-rustdoc-blue.svg)](https://chip8-rust.github.io/chip8-vm/chip8_vm/)

.. or [any custom badge](http://shields.io/#imageMaker) really.

This means that our build status, version info etc. badges depend on the availability of `shields.io`, but then again the images have an `alt` text and do still link somewhere so that's not as bad as it may sound.

What do you think about that change for the build status badges and about possible additional badges like those above, @jakerr ?
Once we settle on something we should apply a similar change to `chip8-rust/chip8-ui`.
