### PR TITLE
Add a CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# How to contribute to `chip8_vm`
+
+So you found a problem or want to add a feature to `chip8_vm`? Great! :+1:
+Below is a list of steps and links to documentation to get you started.
+
+## License
+
+For all of you contributions you need to be aware that they need to comply
+with the project's license.
+You can read the raw [`LICENSE` file](https://github.com/chip8-rust/chip8-vm/blob/master/LICENSE) in the repository. There is a brief summary of the [MIT license on tl;dr Legal](https://tldrlegal.com/license/mit-license).
+
+By contributing to `chip8_vm` you agree that your work will be licensed
+under the project's license. Other people can use `chip8_vm` by obeying
+the same license.
+
+We do not have a formal `contributor license agreement` (CLA) process, it
+is just something you need to be aware of.
+
+## GitHub
+
+To report `issues` or to create `pull requests` you will need to
+[create a GitHub account](https://github.com/join).
+If you already have one, make sure to be signed in.
+
+The `GitHub Guides` contain the following documentation that might be of use:
+
+- [Contributing to Open Source on GitHub](https://guides.github.com/activities/contributing-to-open-source/)
+- [Mastering Issues](https://guides.github.com/features/issues/)
+- [Forking Projects](https://guides.github.com/activities/forking/)
+- [Understanding the GitHub Flow](https://guides.github.com/introduction/flow/)
+
+## Submitting issues
+
+If you have found a problem or got a question, you can create an "issue".
+Please take a look at the [existing issues](https://github.com/chip8-rust/chip8-vm/issues) first, maybe someone else had the same idea as you!
+
+When [creating a new issue](https://github.com/chip8-rust/chip8-vm/issues/new) try sticking to the following check-list:
+
+- Include the version of `chip8_vm` (or git commit) you are using
+- Include the version of `rustc` and `cargo` you are using.
+  You can obtain those by running the following commands in a shell:
+
+  ```sh
+  rustc --version
+  cargo --version
+  ```
+- Include your operating system and version information
+- Include the exact error message or a screenshot of the problem
+- Describe the behaviour that you observe and also describe what you
+  expected to happen instead
+
+## Pull requests
+
+If you want to add a feature or fix some code or documentation, you can create
+a "pull request".
+As with issues, please take a look at the [existing pull requests](https://github.com/chip8-rust/chip8-vm/pulls) first.
+
+Otherwise stick to the following list
+
+- [fork the repository](https://github.com/chip8-rust/chip8-vm/fork)
+- create a new Git branch for your changes and commit them
+- [create a new pull request](https://github.com/chip8-rust/chip8-vm/compare)
+
+Currently there are no formal requirements for code style, required test
+coverage or code documentation or anything like that.
+We will kindly ask you to improve your pull request if it does not match our
+unspoken criterion.
+
+
+If you're still reading, we thank you for your contribution already! :heart:


### PR DESCRIPTION
As explained in the GitHub documentation about [Setting guidelines for repository contributors](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) this adds a `CONTRIBUTING` file to help others contributing to this project.
