### PR TITLE
Add Rust 1.0.0-beta to CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ env:
     - secure: NGqueWme7FGume4ZGrggdLhf1SIkbjni6BphEI0wkXPGYYD+CAQ36/XqadfI1OhJ3ZJgdqcFABJMntdzyGSI3z1SoWc7xgzMEHeW0QusOVBwJMWgMvh/DzXvp8nTG2BmVIhqzqyWVBCqzMARLNh3NnYaJFGnN2uXyXBSBh+K6ps=
     - secure: eh16T+EPdEtelIDMBCj5hiZucybVNRQaZP475KhKRC75UnH4i0163LTcOyaUa4mhVFk8hTGMkBKrLMtW1Bz9AGuOrpUehgRohe1nj93nl1aZZZzuOzV4vwoewkUz2MWjZ+tGXp3oRG0qRNETWxvkZHsJvXf83qylj4+ywAX15d0=
 language: rust
+rust:
+  - nightly
+  - 1.0.0-beta
 sudo: false
 script:
   - cargo build --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     - RUST_VERSION: 1.0.0-beta
 
 install:
-    - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-$Env:RUST_VERSION-$Env:RUST_INSTALL_TRIPLE.exe"
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-$Env:RUST_VERSION-$Env:RUST_INSTALL_TRIPLE.exe"
   - cmd: rust-%RUST_VERSION%-%RUST_INSTALL_TRIPLE%.exe /VERYSILENT /NORESTART /COMPONENTS="rust,gcc,cargo" /DIR="%RUST_INSTALL_DIR%"
   - cmd: SET PATH=%PATH%;%RUST_INSTALL_DIR%\bin
   - rustc --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,12 @@ environment:
   matrix:
     - RUST_INSTALL_TRIPLE: i686-pc-windows-gnu
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-gnu
+    - RUST_VERSION: nightly
+    - RUST_VERSION: 1.0.0-beta
 
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-$Env:RUST_INSTALL_TRIPLE.exe"
-  - cmd: rust-nightly-%RUST_INSTALL_TRIPLE%.exe /VERYSILENT /NORESTART /COMPONENTS="rust,gcc,cargo" /DIR="%RUST_INSTALL_DIR%"
+    - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-$Env:RUST_VERSION-$Env:RUST_INSTALL_TRIPLE.exe"
+  - cmd: rust-%RUST_VERSION%-%RUST_INSTALL_TRIPLE%.exe /VERYSILENT /NORESTART /COMPONENTS="rust,gcc,cargo" /DIR="%RUST_INSTALL_DIR%"
   - cmd: SET PATH=%PATH%;%RUST_INSTALL_DIR%\bin
   - rustc --version
   - cargo --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,13 @@ environment:
   RUST_INSTALL_DIR: C:\Rust
   matrix:
     - RUST_INSTALL_TRIPLE: i686-pc-windows-gnu
+      RUST_VERSION: nightly
+    - RUST_INSTALL_TRIPLE: i686-pc-windows-gnu
+      RUST_VERSION: 1.0.0-beta
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-gnu
-    - RUST_VERSION: nightly
-    - RUST_VERSION: 1.0.0-beta
+      RUST_VERSION: nightly
+    - RUST_INSTALL_TRIPLE: x86_64-pc-windows-gnu
+      RUST_VERSION: 1.0.0-beta
 
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-$Env:RUST_VERSION-$Env:RUST_INSTALL_TRIPLE.exe"


### PR DESCRIPTION
Now that [Rust 1.0 beta](http://blog.rust-lang.org/2015/04/03/Rust-1.0-beta.html) has been released, the CI builds should run for both the latest `nightlies` as well as the latest `stable` version of Rust.

In b2d2a3c2e7f8f3b46cea7e28a21f74ec2c9ee1ac I've fixed/removed code that required feature gates, so the crate works with both today's `nightly` as well as `1.0.0-beta` on my machine ™.

Long term goal should be supporting both the nightlies as well as latest stable version of Rust.

The CI builds are in a somewhat sad state; I've canceled a few non-relevant AppVeyor builds due to overly long queue times and Circle is not working at all right now.
